### PR TITLE
Introduce the S3 Prefix to represent separate upload folders

### DIFF
--- a/src/main/java/tdl/s3/SyncFileApp.java
+++ b/src/main/java/tdl/s3/SyncFileApp.java
@@ -65,7 +65,8 @@ public class SyncFileApp {
                 .withRegion(secretsProvider.getS3Region())
                 .build();
 
-        FileUploadingService fileUploadingService = new FileUploadingService(amazonS3, secretsProvider.getS3Bucket());
+        FileUploadingService fileUploadingService = new FileUploadingService(amazonS3,
+                secretsProvider.getS3Bucket(), secretsProvider.getS3Prefix());
 
         List<Predicate<Path>> filters = FILTERED_EXTENSIONS.stream()
                 .map(ext -> (Predicate<Path>)(path -> ! path.toString().endsWith(ext)))

--- a/src/main/java/tdl/s3/credentials/AWSSecretsProvider.java
+++ b/src/main/java/tdl/s3/credentials/AWSSecretsProvider.java
@@ -43,6 +43,10 @@ public class AWSSecretsProvider implements AWSCredentialsProvider {
         return privateProperties.getProperty("s3_bucket");
     }
 
+    public String getS3Prefix() {
+        return privateProperties.getProperty("s3_prefix");
+    }
+
     @Override
     public void refresh() {
         privateProperties = loadPrivateProperties(privatePropertiesPath);

--- a/src/main/java/tdl/s3/upload/FileUploaderImpl.java
+++ b/src/main/java/tdl/s3/upload/FileUploaderImpl.java
@@ -14,12 +14,13 @@ public class FileUploaderImpl implements FileUploader {
 
     private final AmazonS3 s3Provider;
     private final String bucket;
-
+    private final String prefix;
     private final UploadingStrategy uploadingStrategy;
 
-    public FileUploaderImpl(final AmazonS3 s3Provider, String bucket, UploadingStrategy uploadingStrategy) {
+    public FileUploaderImpl(final AmazonS3 s3Provider, String bucket, String prefix, UploadingStrategy uploadingStrategy) {
         this.s3Provider = s3Provider;
         this.bucket = bucket;
+        this.prefix = prefix;
         this.uploadingStrategy = uploadingStrategy;
     }
 
@@ -36,7 +37,7 @@ public class FileUploaderImpl implements FileUploader {
     @Override
     public boolean exists(String bucketName, String fileKey) {
         try {
-            s3Provider.getObjectMetadata(bucketName, fileKey);
+            s3Provider.getObjectMetadata(bucketName, prefix + fileKey);
             return true;
         }catch (NotFoundException nfe) {
             return false;
@@ -53,7 +54,7 @@ public class FileUploaderImpl implements FileUploader {
         log.info("Uploading file " + file);
         try {
             if (!exists(bucket, newName)) {
-                uploadInternal(s3Provider, bucket, file, newName);
+                uploadInternal(s3Provider, bucket, prefix, file, newName);
             }
         } catch (Exception e) {
             if (retry == 0) {
@@ -66,7 +67,7 @@ public class FileUploaderImpl implements FileUploader {
         }
     }
 
-    private void uploadInternal(AmazonS3 s3, String bucket, File file, String newName) throws Exception {
-        uploadingStrategy.upload(s3, bucket, file, newName);
+    private void uploadInternal(AmazonS3 s3, String bucket, String prefix, File file, String newName) throws Exception {
+        uploadingStrategy.upload(s3, bucket, prefix, file, newName);
     }
 }

--- a/src/main/java/tdl/s3/upload/LargeFileUploadingStrategy.java
+++ b/src/main/java/tdl/s3/upload/LargeFileUploadingStrategy.java
@@ -18,13 +18,13 @@ import java.util.Date;
 public class LargeFileUploadingStrategy implements UploadingStrategy {
 
     @Override
-    public void upload(AmazonS3 s3, String bucket, File file, String newName) throws Exception {
+    public void upload(AmazonS3 s3, String bucket, String prefix, File file, String newName) throws Exception {
         log.debug("Uploading file " + file + " with LargeFileUploadingStrategy.");
         TransferManager transferManager = TransferManagerBuilder
                 .standard()
                 .withS3Client(s3)
                 .build();
-        Upload upload = transferManager.upload(bucket, newName, file);
+        Upload upload = transferManager.upload(bucket, prefix + newName, file);
         upload.waitForCompletion();
         new Date(2015, 1, 12);
         transferManager.shutdownNow(false);

--- a/src/main/java/tdl/s3/upload/SmallFileUploadingStrategy.java
+++ b/src/main/java/tdl/s3/upload/SmallFileUploadingStrategy.java
@@ -10,9 +10,9 @@ import java.io.File;
 public class SmallFileUploadingStrategy implements UploadingStrategy {
 
     @Override
-    public void upload(AmazonS3 s3, String bucket, File file, String newName) {
+    public void upload(AmazonS3 s3, String bucket, String prefix, File file, String newName) {
         log.debug("Uploading file " + file + " with SmallFileUploadingStrategy.");
-        s3.putObject(bucket, newName, file);
+        s3.putObject(bucket, prefix + newName, file);
     }
 
 }

--- a/src/main/java/tdl/s3/upload/UploadingStrategy.java
+++ b/src/main/java/tdl/s3/upload/UploadingStrategy.java
@@ -6,5 +6,5 @@ import java.io.File;
 
 public interface UploadingStrategy {
 
-    void upload(AmazonS3 s3, String bucket, File file, String newName) throws Exception;
+    void upload(AmazonS3 s3, String bucket, String prefix, File file, String newName) throws Exception;
 }

--- a/src/test/java/tdl/s3/upload/FileUploadingServiceTest.java
+++ b/src/test/java/tdl/s3/upload/FileUploadingServiceTest.java
@@ -5,8 +5,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.MultipartUpload;
 import com.amazonaws.services.s3.model.MultipartUploadListing;
-import org.hamcrest.Matcher;
-import org.hamcrest.beans.HasPropertyWithValue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,7 +68,7 @@ public class FileUploadingServiceTest {
             put(1, smallFileUploadingStrategy);
             put(Integer.MAX_VALUE, multiPartUploadFileUploadingStrategy);
 
-        }}, s3, "testBucket");
+        }}, s3, "testBucket", "testPrefix");
 
         when(smallFile.length()).thenReturn(1255L);
         when(largeFile.length()).thenReturn(6L * 1024 * 1024);
@@ -106,7 +104,7 @@ public class FileUploadingServiceTest {
 
         fileUploadingService.upload(smallFile);
 
-        verify(smallFileUploadingStrategy).upload(any(), any(), any(), any());
+        verify(smallFileUploadingStrategy).upload(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -116,7 +114,7 @@ public class FileUploadingServiceTest {
 
         fileUploadingService.upload(largeFile);
 
-        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any());
+        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -125,7 +123,7 @@ public class FileUploadingServiceTest {
 
         fileUploadingService.upload(incompleteFile);
 
-        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any());
+        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any(), any());
     }
 
 
@@ -136,7 +134,7 @@ public class FileUploadingServiceTest {
 
         fileUploadingService.upload(incompleteFile);
 
-        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any());
+        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -152,6 +150,6 @@ public class FileUploadingServiceTest {
 
         fileUploadingService.upload(incompleteFile);
 
-        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any());
+        verify(multiPartUploadFileUploadingStrategy).upload(any(), any(), any(), any(), any());
     }
 }

--- a/src/test/java/tdl/s3/upload/LargeFileUploaderTest.java
+++ b/src/test/java/tdl/s3/upload/LargeFileUploaderTest.java
@@ -59,7 +59,7 @@ public class LargeFileUploaderTest {
 
         when(amazonS3.getObjectMetadata(anyString(), anyString())).thenReturn(null);
 
-        fileUploader = new FileUploaderImpl(amazonS3, "test_bucket", new LargeFileUploadingStrategy());
+        fileUploader = new FileUploaderImpl(amazonS3, "test_bucket", "test_prefix/", new LargeFileUploadingStrategy());
     }
 
     @Test

--- a/src/test/java/tdl/s3/upload/SimpleFileUploaderTest.java
+++ b/src/test/java/tdl/s3/upload/SimpleFileUploaderTest.java
@@ -56,7 +56,7 @@ public class SimpleFileUploaderTest {
 
         when(amazonS3.getObjectMetadata(anyString(), anyString())).thenReturn(null);
 
-        fileUploader = new FileUploaderImpl(amazonS3, "test_bucket", new SmallFileUploadingStrategy());
+        fileUploader = new FileUploaderImpl(amazonS3, "test_bucket", "test_prefix/", new SmallFileUploadingStrategy());
     }
 
     @Test

--- a/src/test/java/tdl/s3/upload/UnfinishedWritingFileUploadingStrategyTest.java
+++ b/src/test/java/tdl/s3/upload/UnfinishedWritingFileUploadingStrategyTest.java
@@ -57,7 +57,7 @@ public class UnfinishedWritingFileUploadingStrategyTest {
     @Test
     public void upload_newlyCreatedButIncompleteFile() throws Exception {
         MultiPartUploadFileUploadingStrategy strategy = new MultiPartUploadFileUploadingStrategy(null, 1);
-        FileUploader fileUploader = new FileUploaderImpl(amazonS3, "bucket", strategy);
+        FileUploader fileUploader = new FileUploaderImpl(amazonS3, "bucket", "test_prefix/", strategy);
 
         String fileName = "unfinished_writing_file.bin";
         targetSyncFolder.addFileFromResources(fileName);
@@ -76,7 +76,7 @@ public class UnfinishedWritingFileUploadingStrategyTest {
 
 
         MultiPartUploadFileUploadingStrategy newStrategy = new MultiPartUploadFileUploadingStrategy(multipartUpload, 1);
-        FileUploader newFileUploader = new FileUploaderImpl(amazonS3, "bucket", newStrategy);
+        FileUploader newFileUploader = new FileUploaderImpl(amazonS3, "bucket", "test_prefix/", newStrategy);
         //upload the rest of the file
         newFileUploader.upload(targetSyncFolder.getFilePath(fileName).toFile());
 


### PR DESCRIPTION
S3 prefixes will map to different users of the system.
I have fixed this now because it was impacting my testing. Codeship build where deleting files I was uploading locally.

To use the prefix, you should add: `s3_prefix = vasyl/` is `aws-test-secrets`